### PR TITLE
Add Runner's Heart support & marketing pages

### DIFF
--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -2,10 +2,10 @@
 ---
 <section class="hero">
   <img class="hero-avatar" src="/assets/images/avatar.png" alt="우주개구리 아바타" />
-  <h1>우주개구리 | oozoofrog</h1>
-  <p class="hero-tagline">더 나은 개발 경험을 위해</p>
-  <p class="hero-desc">iOS & macOS 앱 개발, 오픈소스 개발 도구를 만드는 우주개구리입니다.</p>
-  <a class="btn btn-primary" href="/projects/">프로젝트 보기</a>
+  <h1>oozoofrog</h1>
+  <p class="hero-tagline">For a Better Dev Experience</p>
+  <p class="hero-desc">Building iOS & macOS apps and open-source developer tools.</p>
+  <a class="btn btn-primary" href="/projects/">View Projects</a>
   <div class="hero-wave">
     <svg viewBox="0 0 1440 80" preserveAspectRatio="none" xmlns="http://www.w3.org/2000/svg">
       <path d="M0,40 C360,80 720,0 1080,40 C1260,60 1380,50 1440,40 L1440,80 L0,80 Z" fill="#fafcfa"/>

--- a/src/components/ProjectCard.astro
+++ b/src/components/ProjectCard.astro
@@ -9,8 +9,9 @@ interface Props {
   tags: string[];
   appstore?: string;
   github?: string;
+  page?: string;
 }
-const { name, slug, tagline, description, status, icon, tags, appstore, github } = Astro.props;
+const { name, slug, tagline, description, status, icon, tags, appstore, github, page } = Astro.props;
 
 const statusIcon = status === 'released' ? '🍎' : status === 'development' ? '🔧' : '📦';
 const statusBarClass = `status-bar-${status.toLowerCase().replace(/\s+/g, '')}`;
@@ -36,6 +37,9 @@ const statusBarClass = `status-bar-${status.toLowerCase().replace(/\s+/g, '')}`;
     ))}
   </div>
   <div class="project-links">
+    {page && (
+      <a class="btn btn-primary" href={page}>Details</a>
+    )}
     {appstore && (
       <a class="btn btn-primary" href={appstore} target="_blank" rel="noopener noreferrer">App Store ↗</a>
     )}

--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -9,25 +9,27 @@ export interface Project {
   tags: string[];
   appstore?: string;
   github?: string;
+  page?: string;
 }
 
 export const projects: Project[] = [
   {
     name: "Runner's Heart",
     slug: "runners-heart",
-    tagline: "심박수 기반 러닝 가이드",
-    description: "Apple Watch와 연동하여 실시간 심박수를 모니터링하고, 최적의 러닝 페이스를 안내하는 앱",
+    tagline: "Heart Rate Based Running Guide",
+    description: "Monitor your real-time heart rate with Apple Watch and get guided to your optimal running pace.",
     status: "released",
     featured: true,
     icon: "/assets/images/projects/runners-heart-icon.png",
     tags: ["SwiftUI", "HealthKit", "WatchOS", "CoreData"],
     appstore: "https://apps.apple.com/us/app/runners-heart/id6758222219",
+    page: "/runners-heart/",
   },
   {
     name: "Tesella",
     slug: "tesella",
-    tagline: "포토 모자이크 생성기",
-    description: "사진 라이브러리의 이미지들로 타겟 사진을 타일 모자이크로 재구성하는 iOS 앱. Swift 6 Strict Concurrency, TDD 기반",
+    tagline: "Photo Mosaic Generator",
+    description: "Reconstruct target photos as tile mosaics using images from your photo library. Built with Swift 6 Strict Concurrency and TDD.",
     status: "development",
     featured: true,
     icon: "/assets/images/projects/tesella-icon.png",
@@ -36,8 +38,8 @@ export const projects: Project[] = [
   {
     name: "PhotoCleaner",
     slug: "photocleaner",
-    tagline: "사진첩 정리 도우미",
-    description: "iCloud 다운로드 실패, 손상된 사진, 중복 사진, 대용량 파일을 감지하고 정리하는 iOS 앱",
+    tagline: "Photo Library Cleaner",
+    description: "Detect and clean up failed iCloud downloads, corrupted photos, duplicates, and large files in your photo library.",
     status: "development",
     featured: true,
     icon: "/assets/images/projects/photocleaner-icon.png",
@@ -46,8 +48,8 @@ export const projects: Project[] = [
   {
     name: "Textify",
     slug: "textify",
-    tagline: "이미지를 텍스트 아트로",
-    description: "이미지를 ASCII/유니코드 텍스트 아트로 변환하는 iOS 앱. Metal 기반 이미지 처리, 모듈러 아키텍처",
+    tagline: "Image to Text Art",
+    description: "Convert images to ASCII/Unicode text art. Metal-based image processing with modular architecture.",
     status: "development",
     featured: true,
     tags: ["SwiftUI", "Metal", "Swift 6", "MVVM"],
@@ -55,8 +57,8 @@ export const projects: Project[] = [
   {
     name: "Unicody",
     slug: "unicody",
-    tagline: "유니코드 텍스트 데코레이션",
-    description: "Zalgo 텍스트, 폰트 스타일 변환 등 유니코드 텍스트 장식을 제공하는 iOS 앱과 커스텀 키보드",
+    tagline: "Unicode Text Decoration",
+    description: "Zalgo text, font style conversion, and Unicode text decorations with a custom keyboard extension.",
     status: "development",
     featured: true,
     tags: ["SwiftUI", "UIKit", "Keyboard Extension", "Swift 6"],

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -3,7 +3,7 @@ interface Props {
   title?: string;
   description?: string;
 }
-const { title = '우주개구리 | oozoofrog', description = 'iOS & macOS 앱 개발, 오픈소스 개발 도구를 만드는 우주개구리입니다.' } = Astro.props;
+const { title = 'oozoofrog', description = 'Building iOS & macOS apps and open-source developer tools.' } = Astro.props;
 import '../styles/global.css';
 import Header from '../components/Header.astro';
 import Footer from '../components/Footer.astro';

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -6,18 +6,18 @@ import BaseLayout from '../layouts/BaseLayout.astro';
   <div class="about">
     <img src="/assets/images/avatar.png" alt="oozoofrog" class="avatar" width="200" />
 
-    <h2>우주개구리 (oozoofrog)</h2>
-    <p>iOS &amp; macOS 앱 개발자. 더 나은 개발 경험과 사용자 경험을 추구합니다.</p>
-    <p>Swift 생태계에서 앱 개발과 개발 도구를 만들고 있습니다.</p>
+    <h2>oozoofrog</h2>
+    <p>iOS & macOS app developer. Pursuing a better developer and user experience.</p>
+    <p>Building apps and developer tools in the Swift ecosystem.</p>
 
-    <h3>주요 기술</h3>
+    <h3>Skills</h3>
     <ul>
-      <li><strong>언어</strong>: Swift, Objective-C</li>
-      <li><strong>프레임워크</strong>: SwiftUI, UIKit, Combine, HealthKit, WatchKit</li>
-      <li><strong>관심사</strong>: 앱 아키텍처, 개발 도구, 오픈소스</li>
+      <li><strong>Languages</strong>: Swift, Objective-C</li>
+      <li><strong>Frameworks</strong>: SwiftUI, UIKit, Combine, HealthKit, WatchKit</li>
+      <li><strong>Interests</strong>: App Architecture, Developer Tools, Open Source</li>
     </ul>
 
-    <h3>연락처</h3>
+    <h3>Contact</h3>
     <ul>
       <li>GitHub: <a href="https://github.com/oozoofrog">oozoofrog</a></li>
       <li>Email: <a href="mailto:oozoofrog@gmail.com">oozoofrog@gmail.com</a></li>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -19,7 +19,7 @@ const recentPosts = allPosts
   <section class="featured-projects">
     <div class="section-header">
       <h2>Featured Projects</h2>
-      <a href="/projects/" class="see-all-pill">모든 프로젝트 보기 &rarr;</a>
+      <a href="/projects/" class="see-all-pill">See All Projects &rarr;</a>
     </div>
     <div class="project-grid">
       {featuredProjects.map(project => (
@@ -31,7 +31,7 @@ const recentPosts = allPosts
   <section class="latest-posts">
     <div class="section-header">
       <h2>Latest Posts</h2>
-      <a href="/blog/" class="see-all-pill">모든 글 보기 &rarr;</a>
+      <a href="/blog/" class="see-all-pill">See All Posts &rarr;</a>
     </div>
     <div class="post-cards">
       {recentPosts.map(post => (

--- a/src/pages/runners-heart/index.astro
+++ b/src/pages/runners-heart/index.astro
@@ -1,0 +1,242 @@
+---
+import BaseLayout from '../../layouts/BaseLayout.astro';
+---
+
+<BaseLayout
+  title="Runner's Heart - Heart Rate Based Running Guide"
+  description="Monitor your real-time heart rate with Apple Watch and get guided to your optimal running pace."
+>
+  <!-- Hero Section -->
+  <section class="hero">
+    <img src="/assets/images/projects/runners-heart-icon.png" alt="Runner's Heart Icon" class="app-icon" />
+    <h1>Runner's Heart</h1>
+    <p class="tagline">Heart Rate Based Running Guide</p>
+    <a href="https://apps.apple.com/us/app/runners-heart/id6758222219" class="btn-download">Download on the App Store</a>
+  </section>
+
+  <!-- Features Section -->
+  <section class="features">
+    <h2>Key Features</h2>
+    <div class="feature-grid">
+      <div class="feature-card">
+        <div class="feature-icon">❤️</div>
+        <h3>Real-Time Heart Rate</h3>
+        <p>Monitor your heart rate in real time with Apple Watch integration</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon">🏃</div>
+        <h3>Optimal Pace Guidance</h3>
+        <p>Get guided to your optimal running pace based on heart rate zones</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon">⌚</div>
+        <h3>Apple Watch</h3>
+        <p>Check everything right from your wrist with the watchOS app</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon">📊</div>
+        <h3>Running Stats</h3>
+        <p>Analyze your running history with HealthKit data</p>
+      </div>
+    </div>
+  </section>
+
+  <!-- CTA Section -->
+  <section class="cta">
+    <h2>Get Started Now</h2>
+    <a href="https://apps.apple.com/us/app/runners-heart/id6758222219" class="btn-download">Download Now</a>
+  </section>
+
+  <!-- Footer Links -->
+  <section class="footer-links">
+    <a href="/runners-heart/support/">Support</a>
+    <span class="separator">·</span>
+    <a href="/runners-heart/privacy/">Privacy Policy</a>
+  </section>
+</BaseLayout>
+
+<style>
+  /* Hero Section */
+  .hero {
+    text-align: center;
+    padding: 80px 20px;
+    background: linear-gradient(135deg, #d0e8f5, var(--sky-blue), #a8cce0);
+    color: var(--dark-green);
+    border-radius: 12px;
+    margin-bottom: 60px;
+  }
+
+  .app-icon {
+    width: 120px;
+    height: 120px;
+    border-radius: 26px;
+    margin-bottom: 24px;
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
+  }
+
+  .hero h1 {
+    font-size: 2.5em;
+    margin-bottom: 12px;
+    color: var(--dark-green);
+    font-weight: 700;
+  }
+
+  .tagline {
+    font-size: 1.3em;
+    color: var(--frog-green-dark);
+    margin-bottom: 32px;
+    font-weight: 500;
+  }
+
+  .btn-download {
+    display: inline-block;
+    padding: 14px 32px;
+    background: linear-gradient(135deg, var(--dark-green), #1a3d0e);
+    color: #fff;
+    border-radius: 24px;
+    font-size: 1em;
+    font-weight: 600;
+    text-decoration: none;
+    transition: transform 0.2s, box-shadow 0.2s;
+  }
+
+  .btn-download:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 8px 20px rgba(45, 80, 22, 0.25);
+    border-bottom: none;
+  }
+
+  /* Features Section */
+  .features {
+    margin-bottom: 60px;
+  }
+
+  .features h2 {
+    font-size: 2em;
+    color: var(--dark-green);
+    margin-bottom: 32px;
+    text-align: center;
+  }
+
+  .feature-grid {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 24px;
+  }
+
+  .feature-card {
+    background: #fff;
+    border: 1.5px solid #e0ebe6;
+    border-radius: 16px;
+    padding: 32px;
+    text-align: center;
+    transition: transform 0.2s, box-shadow 0.2s;
+  }
+
+  .feature-card:hover {
+    transform: translateY(-4px);
+    box-shadow: 0 8px 20px rgba(45, 80, 22, 0.1);
+  }
+
+  .feature-icon {
+    font-size: 3em;
+    margin-bottom: 16px;
+  }
+
+  .feature-card h3 {
+    font-size: 1.2em;
+    color: var(--dark-green);
+    margin-bottom: 8px;
+    font-weight: 600;
+  }
+
+  .feature-card p {
+    color: #556;
+    font-size: 0.95em;
+    line-height: 1.6;
+  }
+
+  /* CTA Section */
+  .cta {
+    text-align: center;
+    padding: 60px 20px;
+    background: linear-gradient(135deg, var(--frog-green), var(--frog-green-dark));
+    border-radius: 16px;
+    margin-bottom: 40px;
+  }
+
+  .cta h2 {
+    font-size: 2em;
+    color: #fff;
+    margin-bottom: 24px;
+    font-weight: 700;
+  }
+
+  .cta .btn-download {
+    background: #fff;
+    color: var(--dark-green);
+  }
+
+  .cta .btn-download:hover {
+    background: #f0f8f0;
+  }
+
+  /* Footer Links */
+  .footer-links {
+    text-align: center;
+    padding: 20px;
+    color: #8a9a92;
+    font-size: 0.9em;
+  }
+
+  .footer-links a {
+    color: var(--frog-green);
+    text-decoration: none;
+  }
+
+  .footer-links a:hover {
+    color: var(--planet-orange);
+  }
+
+  .separator {
+    margin: 0 12px;
+    color: #ccc;
+  }
+
+  /* Responsive */
+  @media (max-width: 600px) {
+    .hero {
+      padding: 60px 20px;
+    }
+
+    .app-icon {
+      width: 100px;
+      height: 100px;
+    }
+
+    .hero h1 {
+      font-size: 2em;
+    }
+
+    .tagline {
+      font-size: 1.1em;
+    }
+
+    .feature-grid {
+      grid-template-columns: 1fr;
+      gap: 16px;
+    }
+
+    .feature-card {
+      padding: 24px;
+    }
+
+    .cta {
+      padding: 40px 20px;
+    }
+
+    .cta h2 {
+      font-size: 1.6em;
+    }
+  }
+</style>

--- a/src/pages/runners-heart/privacy/index.astro
+++ b/src/pages/runners-heart/privacy/index.astro
@@ -1,0 +1,202 @@
+---
+import BaseLayout from '../../../layouts/BaseLayout.astro';
+---
+
+<BaseLayout
+  title="Runner's Heart Privacy Policy"
+  description="Privacy policy for Runner's Heart app - data collection and usage"
+>
+  <article class="privacy-policy">
+    <h1>Runner's Heart Privacy Policy</h1>
+
+    <section>
+      <h2>Overview</h2>
+      <p>Runner's Heart values your privacy. This policy explains what information the app collects and how it is used.</p>
+    </section>
+
+    <section>
+      <h2>Information We Collect</h2>
+      <ul>
+        <li>HealthKit heart rate data (real-time measurement during runs)</li>
+        <li>Running records (distance, time, pace)</li>
+        <li>Heart rate zone settings (configured by the user)</li>
+      </ul>
+    </section>
+
+    <section>
+      <h2>How We Use Information</h2>
+      <ul>
+        <li>Providing real-time running guidance</li>
+        <li>Running statistics and history analysis</li>
+        <li>Heart rate zone-based pace guidance</li>
+      </ul>
+    </section>
+
+    <section>
+      <h2>Data Storage</h2>
+      <ul>
+        <li>All data is stored only on your device</li>
+        <li>No data is transmitted to external servers</li>
+        <li>Data is securely managed through Apple's HealthKit framework</li>
+      </ul>
+    </section>
+
+    <section>
+      <h2>Data Sharing</h2>
+      <ul>
+        <li>We do not share any data with third parties</li>
+        <li>We do not use data for advertising purposes</li>
+        <li>We do not use analytics tools or trackers</li>
+      </ul>
+    </section>
+
+    <section>
+      <h2>Data Deletion</h2>
+      <ul>
+        <li>Deleting the app removes all app data</li>
+        <li>HealthKit data can be managed separately in the Health app</li>
+      </ul>
+    </section>
+
+    <section>
+      <h2>Contact</h2>
+      <p>For privacy-related inquiries, please contact us at <a href="mailto:oozoofrog@gmail.com">oozoofrog@gmail.com</a>.</p>
+    </section>
+
+    <section>
+      <h2>Effective Date</h2>
+      <p>Effective from January 1, 2025</p>
+    </section>
+
+    <nav class="page-nav">
+      <a href="/runners-heart/" class="nav-link">Home</a>
+      <a href="/runners-heart/support/" class="nav-link">Support</a>
+    </nav>
+  </article>
+</BaseLayout>
+
+<style>
+  .privacy-policy {
+    max-width: 800px;
+    margin: 0 auto;
+    padding: 40px 20px;
+  }
+
+  h1 {
+    font-size: 2.2em;
+    color: var(--dark-green);
+    margin-bottom: 40px;
+    padding-bottom: 16px;
+    border-bottom: 3px solid var(--frog-green);
+  }
+
+  section {
+    margin-bottom: 40px;
+  }
+
+  h2 {
+    font-size: 1.5em;
+    color: var(--dark-green);
+    margin-bottom: 16px;
+    position: relative;
+    padding-left: 16px;
+  }
+
+  h2::before {
+    content: '';
+    position: absolute;
+    left: 0;
+    top: 50%;
+    transform: translateY(-50%);
+    width: 4px;
+    height: 1.2em;
+    background: var(--frog-green);
+    border-radius: 2px;
+  }
+
+  p {
+    color: #333;
+    line-height: 1.8;
+    margin-bottom: 12px;
+  }
+
+  ul {
+    list-style: none;
+    padding-left: 0;
+  }
+
+  li {
+    color: #333;
+    line-height: 1.8;
+    margin-bottom: 8px;
+    padding-left: 24px;
+    position: relative;
+  }
+
+  li::before {
+    content: '•';
+    color: var(--frog-green);
+    font-weight: bold;
+    position: absolute;
+    left: 8px;
+  }
+
+  a {
+    color: var(--frog-green);
+    text-decoration: none;
+    border-bottom: 1.5px solid transparent;
+    transition: color 0.2s ease, border-bottom 0.2s ease;
+  }
+
+  a:hover {
+    color: var(--planet-orange);
+    border-bottom: 1.5px solid var(--planet-orange);
+  }
+
+  .page-nav {
+    display: flex;
+    gap: 16px;
+    margin-top: 60px;
+    padding-top: 40px;
+    border-top: 1px solid #e0ebe6;
+    flex-wrap: wrap;
+  }
+
+  .nav-link {
+    display: inline-block;
+    padding: 10px 20px;
+    background: var(--frog-green);
+    color: #fff;
+    border-radius: 20px;
+    font-weight: 600;
+    transition: transform 0.15s, box-shadow 0.15s;
+  }
+
+  .nav-link:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 6px 16px rgba(45, 80, 22, 0.15);
+    border-bottom: 1.5px solid transparent;
+  }
+
+  @media (max-width: 600px) {
+    .privacy-policy {
+      padding: 24px 16px;
+    }
+
+    h1 {
+      font-size: 1.8em;
+    }
+
+    h2 {
+      font-size: 1.3em;
+    }
+
+    .page-nav {
+      flex-direction: column;
+    }
+
+    .nav-link {
+      text-align: center;
+    }
+  }
+</style>

--- a/src/pages/runners-heart/support/index.astro
+++ b/src/pages/runners-heart/support/index.astro
@@ -1,0 +1,352 @@
+---
+import BaseLayout from '../../../layouts/BaseLayout.astro';
+---
+
+<BaseLayout
+  title="Runner's Heart Support"
+  description="Have questions or issues with Runner's Heart? Check our FAQ and contact information."
+>
+  <div class="support-page">
+    <header class="page-header">
+      <h1>Runner's Heart Support</h1>
+      <p class="intro">Have questions or running into issues? Check the FAQ below or contact us directly.</p>
+    </header>
+
+    <section class="faq-section">
+      <h2>FAQ</h2>
+      <div class="faq-list">
+        <details>
+          <summary>
+            <span class="icon">▶</span>
+            <span class="question">Which Apple Watch models are supported?</span>
+          </summary>
+          <div class="answer">
+            <p>Runner's Heart supports all <strong>Apple Watch Series 3 and later</strong> models. Requires watchOS 9.0 or later.</p>
+          </div>
+        </details>
+
+        <details>
+          <summary>
+            <span class="icon">▶</span>
+            <span class="question">Where is my heart rate data stored?</span>
+          </summary>
+          <div class="answer">
+            <p>All data is stored <strong>only in HealthKit on your device</strong> and is never transmitted to external servers. Your privacy is fully protected.</p>
+          </div>
+        </details>
+
+        <details>
+          <summary>
+            <span class="icon">▶</span>
+            <span class="question">Do I need an internet connection?</span>
+          </summary>
+          <div class="answer">
+            <p><strong>No internet connection is required</strong> during your run. All features work fully offline.</p>
+          </div>
+        </details>
+
+        <details>
+          <summary>
+            <span class="icon">▶</span>
+            <span class="question">Does it drain my battery?</span>
+          </summary>
+          <div class="answer">
+            <p>Optimized heart rate sensor access <strong>minimizes battery consumption</strong>. Battery usage is comparable to other running apps.</p>
+          </div>
+        </details>
+
+        <details>
+          <summary>
+            <span class="icon">▶</span>
+            <span class="question">Can I back up my data?</span>
+          </summary>
+          <div class="answer">
+            <p>HealthKit data is <strong>automatically backed up via iCloud</strong>. Your data is preserved when switching or restoring devices.</p>
+          </div>
+        </details>
+      </div>
+    </section>
+
+    <section class="contact-section">
+      <h2>Contact Us</h2>
+      <p class="contact-intro">If you encounter any issues or have suggestions, please let us know via email.</p>
+      <div class="contact-info">
+        <div class="contact-item">
+          <span class="label">Email</span>
+          <a href="mailto:oozoofrog@gmail.com" class="email-link">oozoofrog@gmail.com</a>
+        </div>
+      </div>
+    </section>
+
+    <footer class="page-footer">
+      <nav class="footer-links">
+        <a href="/runners-heart/">Home</a>
+        <span class="separator">•</span>
+        <a href="/runners-heart/privacy/">Privacy Policy</a>
+      </nav>
+    </footer>
+  </div>
+</BaseLayout>
+
+<style>
+  .support-page {
+    max-width: 800px;
+    margin: 0 auto;
+  }
+
+  .page-header {
+    text-align: center;
+    margin-bottom: 48px;
+    padding: 40px 20px;
+    background: linear-gradient(135deg, #d0e8f5, var(--sky-blue), #a8cce0);
+    border-radius: 12px;
+  }
+
+  .page-header h1 {
+    font-size: 2.2em;
+    color: var(--dark-green);
+    margin-bottom: 12px;
+  }
+
+  .intro {
+    font-size: 1.1em;
+    color: var(--frog-green-dark);
+    line-height: 1.6;
+  }
+
+  /* FAQ Section */
+  .faq-section {
+    margin-bottom: 48px;
+  }
+
+  .faq-section h2 {
+    font-size: 1.8em;
+    color: var(--dark-green);
+    margin-bottom: 24px;
+    position: relative;
+    padding-left: 16px;
+  }
+
+  .faq-section h2::before {
+    content: '';
+    position: absolute;
+    left: 0;
+    top: 0;
+    width: 4px;
+    height: 100%;
+    background: var(--frog-green);
+    border-radius: 2px;
+  }
+
+  .faq-list {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+  }
+
+  details {
+    background: #fff;
+    border: 1.5px solid #e0ebe6;
+    border-radius: 12px;
+    padding: 20px;
+    transition: all 0.2s ease;
+  }
+
+  details:hover {
+    border-color: var(--frog-green);
+    box-shadow: 0 2px 8px rgba(45, 80, 22, 0.08);
+  }
+
+  details[open] {
+    border-color: var(--frog-green);
+    box-shadow: 0 4px 12px rgba(45, 80, 22, 0.12);
+  }
+
+  summary {
+    cursor: pointer;
+    user-select: none;
+    list-style: none;
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    font-weight: 600;
+    color: var(--dark-green);
+    font-size: 1.05em;
+  }
+
+  summary::-webkit-details-marker {
+    display: none;
+  }
+
+  .icon {
+    display: inline-block;
+    width: 20px;
+    height: 20px;
+    flex-shrink: 0;
+    color: var(--frog-green);
+    transition: transform 0.2s ease;
+    font-size: 0.8em;
+  }
+
+  details[open] .icon {
+    transform: rotate(90deg);
+  }
+
+  .question {
+    flex: 1;
+  }
+
+  .answer {
+    margin-top: 16px;
+    padding-top: 16px;
+    border-top: 1px solid #e8f0ec;
+    color: #556;
+    line-height: 1.7;
+    animation: fadeIn 0.2s ease;
+  }
+
+  @keyframes fadeIn {
+    from {
+      opacity: 0;
+      transform: translateY(-4px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+
+  .answer p {
+    margin: 0;
+  }
+
+  .answer strong {
+    color: var(--dark-green);
+  }
+
+  /* Contact Section */
+  .contact-section {
+    margin-bottom: 48px;
+    padding: 32px;
+    background: #fff;
+    border: 1.5px solid #e0ebe6;
+    border-radius: 12px;
+  }
+
+  .contact-section h2 {
+    font-size: 1.8em;
+    color: var(--dark-green);
+    margin-bottom: 16px;
+    position: relative;
+    padding-left: 16px;
+  }
+
+  .contact-section h2::before {
+    content: '';
+    position: absolute;
+    left: 0;
+    top: 0;
+    width: 4px;
+    height: 100%;
+    background: var(--frog-green);
+    border-radius: 2px;
+  }
+
+  .contact-intro {
+    color: #556;
+    line-height: 1.7;
+    margin-bottom: 24px;
+  }
+
+  .contact-info {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+  }
+
+  .contact-item {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+  }
+
+  .label {
+    font-weight: 600;
+    color: var(--dark-green);
+    min-width: 60px;
+  }
+
+  .email-link {
+    color: var(--frog-green);
+    font-weight: 500;
+    padding: 8px 16px;
+    background: var(--sky-blue-light);
+    border-radius: 8px;
+    transition: all 0.2s ease;
+    border-bottom: none;
+  }
+
+  .email-link:hover {
+    background: var(--sky-blue);
+    color: var(--dark-green);
+    transform: translateY(-1px);
+    border-bottom: none;
+  }
+
+  /* Page Footer */
+  .page-footer {
+    text-align: center;
+    padding: 32px 20px;
+    border-top: 1px solid #e8f0ec;
+  }
+
+  .footer-links {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: 12px;
+    flex-wrap: wrap;
+  }
+
+  .separator {
+    color: #ccc;
+  }
+
+  /* Responsive */
+  @media (max-width: 600px) {
+    .page-header {
+      padding: 32px 16px;
+    }
+
+    .page-header h1 {
+      font-size: 1.7em;
+    }
+
+    .intro {
+      font-size: 1em;
+    }
+
+    .faq-section h2,
+    .contact-section h2 {
+      font-size: 1.5em;
+    }
+
+    details {
+      padding: 16px;
+    }
+
+    summary {
+      font-size: 1em;
+    }
+
+    .contact-section {
+      padding: 24px 20px;
+    }
+
+    .contact-item {
+      flex-direction: column;
+      align-items: flex-start;
+      gap: 8px;
+    }
+  }
+</style>


### PR DESCRIPTION
## Summary
- Add `/runners-heart/` marketing landing page (hero, features grid, App Store CTA)
- Add `/runners-heart/support/` FAQ page with CSS-only accordion (details/summary)
- Add `/runners-heart/privacy/` privacy policy page
- Add `page` prop to ProjectCard for detail page link ("Details" button)
- Convert all non-blog content from Korean to English

## Test plan
- [ ] Verify `/runners-heart/` landing page renders correctly
- [ ] Verify `/runners-heart/support/` FAQ accordion works
- [ ] Verify `/runners-heart/privacy/` displays all sections
- [ ] Verify ProjectCard "Details" button links to `/runners-heart/`
- [ ] Verify all non-blog pages display in English
- [ ] Verify blog posts remain in Korean

Closes #2