### PR TITLE
Apply Liquid Glass design across all pages

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -19,22 +19,21 @@
 
 <style>
   .site-footer {
-    background: #f5f9f6;
+    background: rgba(255, 255, 255, 0.35);
+    backdrop-filter: blur(16px);
+    -webkit-backdrop-filter: blur(16px);
     padding: 40px 20px;
     margin-top: 40px;
     text-align: center;
     color: #8a9a92;
     font-size: 0.85em;
     position: relative;
+    border-top: 1px solid rgba(255, 255, 255, 0.4);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.5);
   }
 
   .footer-gradient {
-    position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    height: 1px;
-    background: linear-gradient(to right, transparent, var(--sky-blue), transparent);
+    display: none;
   }
 
   .footer-inner {

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -37,10 +37,11 @@ const navItems = [
     position: sticky;
     top: 0;
     z-index: 100;
-    background: rgba(255, 255, 255, 0.85);
-    backdrop-filter: blur(12px);
-    -webkit-backdrop-filter: blur(12px);
-    border-bottom: 1px solid rgba(0, 0, 0, 0.06);
+    background: rgba(255, 255, 255, 0.35);
+    backdrop-filter: blur(24px) saturate(180%);
+    -webkit-backdrop-filter: blur(24px) saturate(180%);
+    border-bottom: 1px solid rgba(255, 255, 255, 0.3);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.5), 0 1px 3px rgba(0, 0, 0, 0.05);
     padding: 0 20px;
   }
 
@@ -90,12 +91,15 @@ const navItems = [
 
   nav a:hover {
     color: var(--frog-green);
-    background: var(--sky-blue-light);
+    background: rgba(255, 255, 255, 0.5);
   }
 
   nav a.active {
     color: var(--dark-green);
-    background: var(--sky-blue-light);
+    background: rgba(255, 255, 255, 0.6);
+    backdrop-filter: blur(8px);
+    -webkit-backdrop-filter: blur(8px);
+    border: 1px solid rgba(255, 255, 255, 0.4);
   }
 
   /* Hamburger menu */

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -6,11 +6,7 @@
   <p class="hero-tagline">For a Better Dev Experience</p>
   <p class="hero-desc">Building iOS & macOS apps and open-source developer tools.</p>
   <a class="btn btn-primary" href="/projects/">View Projects</a>
-  <div class="hero-wave">
-    <svg viewBox="0 0 1440 80" preserveAspectRatio="none" xmlns="http://www.w3.org/2000/svg">
-      <path d="M0,40 C360,80 720,0 1080,40 C1260,60 1380,50 1440,40 L1440,80 L0,80 Z" fill="#fafcfa"/>
-    </svg>
-  </div>
+  <div class="hero-gradient-fade"></div>
 </section>
 
 <style>
@@ -23,17 +19,13 @@
     50% { transform: translateY(-6px); }
   }
 
-  .hero-wave {
+  .hero-gradient-fade {
     position: absolute;
     bottom: 0;
     left: 0;
     width: 100%;
-    line-height: 0;
-  }
-
-  .hero-wave svg {
-    width: 100%;
-    height: 60px;
-    display: block;
+    height: 80px;
+    background: linear-gradient(to bottom, transparent, rgba(255, 255, 255, 0.3));
+    pointer-events: none;
   }
 </style>

--- a/src/components/ProjectCard.astro
+++ b/src/components/ProjectCard.astro
@@ -52,19 +52,22 @@ const statusBarClass = `status-bar-${status.toLowerCase().replace(/\s+/g, '')}`;
 <style>
   .project-card {
     position: relative;
-    background: #fff;
-    border: 1.5px solid #e0ebe6;
+    background: rgba(255, 255, 255, 0.45);
+    backdrop-filter: blur(20px) saturate(150%);
+    -webkit-backdrop-filter: blur(20px) saturate(150%);
+    border: 1px solid rgba(255, 255, 255, 0.5);
     border-radius: 12px;
     padding: 24px;
     padding-top: 28px;
     overflow: hidden;
-    transition: transform 0.15s, box-shadow 0.15s, border-color 0.15s;
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.08), inset 0 1px 0 rgba(255, 255, 255, 0.6);
+    transition: transform 0.15s, box-shadow 0.15s, background 0.15s;
   }
 
   .project-card:hover {
-    transform: translateY(-2px);
-    border-color: var(--frog-green);
-    box-shadow: 0 8px 24px rgba(45, 80, 22, 0.15);
+    transform: translateY(-2px) scale(1.01);
+    background: rgba(255, 255, 255, 0.65);
+    box-shadow: 0 12px 40px rgba(0, 0, 0, 0.12), inset 0 1px 0 rgba(255, 255, 255, 0.8);
   }
 
   /* Status color bar at top */
@@ -74,6 +77,7 @@ const statusBarClass = `status-bar-${status.toLowerCase().replace(/\s+/g, '')}`;
     left: 0;
     right: 0;
     height: 4px;
+    opacity: 0.8;
   }
 
   .status-bar-released {
@@ -155,17 +159,21 @@ const statusBarClass = `status-bar-${status.toLowerCase().replace(/\s+/g, '')}`;
   }
 
   .tag {
-    background: var(--sky-blue-light);
+    background: rgba(255, 255, 255, 0.5);
+    backdrop-filter: blur(8px);
+    -webkit-backdrop-filter: blur(8px);
     color: var(--frog-green-dark);
     padding: 3px 10px;
     border-radius: 12px;
     font-size: 0.78em;
     font-weight: 500;
-    transition: background 0.15s;
+    border: 1px solid rgba(255, 255, 255, 0.6);
+    transition: background 0.15s, border-color 0.15s;
   }
 
   .tag:hover {
-    background: var(--sky-blue);
+    background: rgba(255, 255, 255, 0.7);
+    border-color: rgba(255, 255, 255, 0.8);
   }
 
   /* Links */
@@ -182,7 +190,9 @@ const statusBarClass = `status-bar-${status.toLowerCase().replace(/\s+/g, '')}`;
     text-decoration: none;
     font-size: 0.9em;
     font-weight: 600;
-    transition: transform 0.15s, box-shadow 0.15s;
+    backdrop-filter: blur(8px);
+    -webkit-backdrop-filter: blur(8px);
+    transition: transform 0.15s, box-shadow 0.15s, background 0.15s;
   }
 
   .project-links .btn:hover {
@@ -196,8 +206,12 @@ const statusBarClass = `status-bar-${status.toLowerCase().replace(/\s+/g, '')}`;
   }
 
   .project-links .btn-secondary {
-    background: #fff;
+    background: rgba(255, 255, 255, 0.6);
     color: var(--dark-green);
-    border: 1.5px solid #d0d8d4;
+    border: 1px solid rgba(255, 255, 255, 0.8);
+  }
+
+  .project-links .btn-secondary:hover {
+    background: rgba(255, 255, 255, 0.8);
   }
 </style>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -28,10 +28,45 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 <style>
   .about {
     max-width: 640px;
+    background: rgba(255, 255, 255, 0.45);
+    backdrop-filter: blur(20px) saturate(150%);
+    -webkit-backdrop-filter: blur(20px) saturate(150%);
+    border: 1px solid rgba(255, 255, 255, 0.5);
+    border-radius: 16px;
+    padding: 40px;
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.08), inset 0 1px 0 rgba(255, 255, 255, 0.6);
+  }
+
+  @supports not (backdrop-filter: blur(20px)) {
+    .about {
+      background: rgba(255, 255, 255, 0.85);
+    }
   }
 
   .avatar {
     border-radius: 50%;
     margin-bottom: 1.5rem;
+    box-shadow: 0 0 0 3px rgba(255, 255, 255, 0.6), 0 0 20px rgba(112, 168, 80, 0.2), 0 4px 16px rgba(0, 0, 0, 0.12);
+    position: relative;
+  }
+
+  .about ul li {
+    transition: all 0.2s;
+  }
+
+  .about ul li:hover {
+    background: rgba(255, 255, 255, 0.3);
+    backdrop-filter: blur(8px);
+    -webkit-backdrop-filter: blur(8px);
+    padding: 4px 12px;
+    margin-left: -12px;
+    border-radius: 8px;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
+  }
+
+  @supports not (backdrop-filter: blur(8px)) {
+    .about ul li:hover {
+      background: rgba(255, 255, 255, 0.6);
+    }
   }
 </style>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -66,13 +66,17 @@ const recentPosts = allPosts
     font-size: 0.85rem;
     font-weight: 600;
     color: var(--frog-green);
-    background: var(--sky-blue-light);
-    transition: background 0.15s, color 0.15s;
+    background: rgba(255, 255, 255, 0.5);
+    backdrop-filter: blur(8px);
+    -webkit-backdrop-filter: blur(8px);
+    border: 1px solid rgba(255, 255, 255, 0.6);
+    transition: background 0.15s, color 0.15s, border-color 0.15s;
   }
 
   .see-all-pill:hover {
     background: var(--frog-green);
     color: #fff;
+    border-color: var(--frog-green);
   }
 
   .featured-projects,
@@ -99,14 +103,18 @@ const recentPosts = allPosts
     gap: 1rem;
     padding: 12px 16px;
     border-radius: 8px;
-    border: 1px solid #e0ebe6;
-    background: #fff;
-    transition: background 0.15s, transform 0.15s;
+    border: 1px solid rgba(255, 255, 255, 0.4);
+    background: rgba(255, 255, 255, 0.4);
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.04), inset 0 1px 0 rgba(255, 255, 255, 0.5);
+    transition: background 0.15s, transform 0.15s, box-shadow 0.15s;
   }
 
   .post-card:hover {
-    background: var(--sky-blue-light);
+    background: rgba(255, 255, 255, 0.6);
     transform: translateX(4px);
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08), inset 0 1px 0 rgba(255, 255, 255, 0.6);
   }
 
   .post-card time {

--- a/src/pages/runners-heart/index.astro
+++ b/src/pages/runners-heart/index.astro
@@ -60,10 +60,31 @@ import BaseLayout from '../../layouts/BaseLayout.astro';
   .hero {
     text-align: center;
     padding: 80px 20px;
-    background: linear-gradient(135deg, #d0e8f5, var(--sky-blue), #a8cce0);
+    background: rgba(255, 255, 255, 0.45);
+    backdrop-filter: blur(24px) saturate(150%);
+    -webkit-backdrop-filter: blur(24px) saturate(150%);
+    border: 1px solid rgba(255, 255, 255, 0.5);
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.08), inset 0 1px 0 rgba(255, 255, 255, 0.6);
     color: var(--dark-green);
-    border-radius: 12px;
+    border-radius: 16px;
     margin-bottom: 60px;
+    position: relative;
+  }
+
+  .hero::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(135deg, #d0e8f5, var(--sky-blue), #a8cce0);
+    border-radius: 16px;
+    z-index: -1;
+    opacity: 0.3;
+  }
+
+  @supports not (backdrop-filter: blur(24px)) {
+    .hero {
+      background: rgba(255, 255, 255, 0.75);
+    }
   }
 
   .app-icon {
@@ -91,19 +112,30 @@ import BaseLayout from '../../layouts/BaseLayout.astro';
   .btn-download {
     display: inline-block;
     padding: 14px 32px;
-    background: linear-gradient(135deg, var(--dark-green), #1a3d0e);
+    background: rgba(45, 80, 22, 0.75);
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
     color: #fff;
+    border: 1px solid rgba(255, 255, 255, 0.3);
     border-radius: 24px;
     font-size: 1em;
     font-weight: 600;
     text-decoration: none;
-    transition: transform 0.2s, box-shadow 0.2s;
+    transition: all 0.2s;
+    box-shadow: 0 4px 16px rgba(45, 80, 22, 0.2), inset 0 1px 0 rgba(255, 255, 255, 0.2);
   }
 
   .btn-download:hover {
     transform: translateY(-2px);
-    box-shadow: 0 8px 20px rgba(45, 80, 22, 0.25);
+    background: rgba(45, 80, 22, 0.85);
+    box-shadow: 0 8px 24px rgba(45, 80, 22, 0.3), inset 0 1px 0 rgba(255, 255, 255, 0.3);
     border-bottom: none;
+  }
+
+  @supports not (backdrop-filter: blur(12px)) {
+    .btn-download {
+      background: rgba(45, 80, 22, 0.9);
+    }
   }
 
   /* Features Section */
@@ -125,17 +157,30 @@ import BaseLayout from '../../layouts/BaseLayout.astro';
   }
 
   .feature-card {
-    background: #fff;
-    border: 1.5px solid #e0ebe6;
+    background: rgba(255, 255, 255, 0.5);
+    backdrop-filter: blur(20px) saturate(150%);
+    -webkit-backdrop-filter: blur(20px) saturate(150%);
+    border: 1px solid rgba(255, 255, 255, 0.6);
     border-radius: 16px;
     padding: 32px;
     text-align: center;
-    transition: transform 0.2s, box-shadow 0.2s;
+    transition: all 0.2s;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.06), inset 0 1px 0 rgba(255, 255, 255, 0.5);
   }
 
   .feature-card:hover {
     transform: translateY(-4px);
-    box-shadow: 0 8px 20px rgba(45, 80, 22, 0.1);
+    background: rgba(255, 255, 255, 0.65);
+    box-shadow: 0 12px 32px rgba(0, 0, 0, 0.1), inset 0 1px 0 rgba(255, 255, 255, 0.7);
+  }
+
+  @supports not (backdrop-filter: blur(20px)) {
+    .feature-card {
+      background: rgba(255, 255, 255, 0.85);
+    }
+    .feature-card:hover {
+      background: rgba(255, 255, 255, 0.95);
+    }
   }
 
   .feature-icon {
@@ -160,9 +205,24 @@ import BaseLayout from '../../layouts/BaseLayout.astro';
   .cta {
     text-align: center;
     padding: 60px 20px;
-    background: linear-gradient(135deg, var(--frog-green), var(--frog-green-dark));
+    position: relative;
     border-radius: 16px;
     margin-bottom: 40px;
+    background: rgba(255, 255, 255, 0.4);
+    backdrop-filter: blur(24px);
+    -webkit-backdrop-filter: blur(24px);
+    border: 1px solid rgba(255, 255, 255, 0.5);
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.08), inset 0 1px 0 rgba(255, 255, 255, 0.6);
+  }
+
+  .cta::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(135deg, var(--frog-green), var(--frog-green-dark));
+    border-radius: 16px;
+    z-index: -1;
+    opacity: 0.6;
   }
 
   .cta h2 {
@@ -170,15 +230,29 @@ import BaseLayout from '../../layouts/BaseLayout.astro';
     color: #fff;
     margin-bottom: 24px;
     font-weight: 700;
+    text-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
   }
 
   .cta .btn-download {
-    background: #fff;
+    background: rgba(255, 255, 255, 0.85);
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
     color: var(--dark-green);
+    border: 1px solid rgba(255, 255, 255, 0.6);
   }
 
   .cta .btn-download:hover {
-    background: #f0f8f0;
+    background: rgba(255, 255, 255, 0.95);
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12), inset 0 1px 0 rgba(255, 255, 255, 0.8);
+  }
+
+  @supports not (backdrop-filter: blur(24px)) {
+    .cta {
+      background: rgba(255, 255, 255, 0.7);
+    }
+    .cta .btn-download {
+      background: rgba(255, 255, 255, 0.95);
+    }
   }
 
   /* Footer Links */
@@ -192,10 +266,26 @@ import BaseLayout from '../../layouts/BaseLayout.astro';
   .footer-links a {
     color: var(--frog-green);
     text-decoration: none;
+    padding: 6px 14px;
+    background: rgba(255, 255, 255, 0.4);
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    border: 1px solid rgba(255, 255, 255, 0.4);
+    border-radius: 16px;
+    transition: all 0.2s;
+    display: inline-block;
   }
 
   .footer-links a:hover {
     color: var(--planet-orange);
+    background: rgba(255, 255, 255, 0.55);
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+  }
+
+  @supports not (backdrop-filter: blur(12px)) {
+    .footer-links a {
+      background: rgba(255, 255, 255, 0.75);
+    }
   }
 
   .separator {

--- a/src/pages/runners-heart/privacy/index.astro
+++ b/src/pages/runners-heart/privacy/index.astro
@@ -80,6 +80,18 @@ import BaseLayout from '../../../layouts/BaseLayout.astro';
     max-width: 800px;
     margin: 0 auto;
     padding: 40px 20px;
+    background: rgba(255, 255, 255, 0.35);
+    backdrop-filter: blur(20px) saturate(150%);
+    -webkit-backdrop-filter: blur(20px) saturate(150%);
+    border: 1px solid rgba(255, 255, 255, 0.5);
+    border-radius: 16px;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.06), inset 0 1px 0 rgba(255, 255, 255, 0.4);
+  }
+
+  @supports not (backdrop-filter: blur(20px)) {
+    .privacy-policy {
+      background: rgba(255, 255, 255, 0.75);
+    }
   }
 
   h1 {
@@ -165,17 +177,28 @@ import BaseLayout from '../../../layouts/BaseLayout.astro';
   .nav-link {
     display: inline-block;
     padding: 10px 20px;
-    background: var(--frog-green);
+    background: rgba(112, 168, 80, 0.75);
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
     color: #fff;
+    border: 1px solid rgba(255, 255, 255, 0.3);
     border-radius: 20px;
     font-weight: 600;
-    transition: transform 0.15s, box-shadow 0.15s;
+    transition: all 0.15s;
+    box-shadow: 0 4px 12px rgba(45, 80, 22, 0.15), inset 0 1px 0 rgba(255, 255, 255, 0.2);
   }
 
   .nav-link:hover {
     transform: translateY(-2px);
-    box-shadow: 0 6px 16px rgba(45, 80, 22, 0.15);
-    border-bottom: 1.5px solid transparent;
+    background: rgba(112, 168, 80, 0.85);
+    box-shadow: 0 6px 20px rgba(45, 80, 22, 0.25), inset 0 1px 0 rgba(255, 255, 255, 0.3);
+    border-bottom: 1px solid rgba(255, 255, 255, 0.3);
+  }
+
+  @supports not (backdrop-filter: blur(12px)) {
+    .nav-link {
+      background: rgba(112, 168, 80, 0.9);
+    }
   }
 
   @media (max-width: 600px) {

--- a/src/pages/runners-heart/support/index.astro
+++ b/src/pages/runners-heart/support/index.astro
@@ -98,8 +98,29 @@ import BaseLayout from '../../../layouts/BaseLayout.astro';
     text-align: center;
     margin-bottom: 48px;
     padding: 40px 20px;
+    background: rgba(255, 255, 255, 0.45);
+    backdrop-filter: blur(24px) saturate(150%);
+    -webkit-backdrop-filter: blur(24px) saturate(150%);
+    border: 1px solid rgba(255, 255, 255, 0.5);
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.08), inset 0 1px 0 rgba(255, 255, 255, 0.6);
+    border-radius: 16px;
+    position: relative;
+  }
+
+  .page-header::before {
+    content: '';
+    position: absolute;
+    inset: 0;
     background: linear-gradient(135deg, #d0e8f5, var(--sky-blue), #a8cce0);
-    border-radius: 12px;
+    border-radius: 16px;
+    z-index: -1;
+    opacity: 0.3;
+  }
+
+  @supports not (backdrop-filter: blur(24px)) {
+    .page-header {
+      background: rgba(255, 255, 255, 0.75);
+    }
   }
 
   .page-header h1 {
@@ -145,21 +166,38 @@ import BaseLayout from '../../../layouts/BaseLayout.astro';
   }
 
   details {
-    background: #fff;
-    border: 1.5px solid #e0ebe6;
+    background: rgba(255, 255, 255, 0.45);
+    backdrop-filter: blur(20px) saturate(150%);
+    -webkit-backdrop-filter: blur(20px) saturate(150%);
+    border: 1px solid rgba(255, 255, 255, 0.5);
     border-radius: 12px;
     padding: 20px;
     transition: all 0.2s ease;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.06), inset 0 1px 0 rgba(255, 255, 255, 0.5);
   }
 
   details:hover {
-    border-color: var(--frog-green);
-    box-shadow: 0 2px 8px rgba(45, 80, 22, 0.08);
+    background: rgba(255, 255, 255, 0.55);
+    border-color: rgba(112, 168, 80, 0.4);
+    box-shadow: 0 6px 20px rgba(0, 0, 0, 0.08), inset 0 1px 0 rgba(255, 255, 255, 0.6);
   }
 
   details[open] {
-    border-color: var(--frog-green);
-    box-shadow: 0 4px 12px rgba(45, 80, 22, 0.12);
+    background: rgba(255, 255, 255, 0.65);
+    border-color: rgba(112, 168, 80, 0.6);
+    box-shadow: 0 8px 24px rgba(45, 80, 22, 0.12), inset 0 1px 0 rgba(255, 255, 255, 0.7), 0 0 20px rgba(112, 168, 80, 0.15);
+  }
+
+  @supports not (backdrop-filter: blur(20px)) {
+    details {
+      background: rgba(255, 255, 255, 0.85);
+    }
+    details:hover {
+      background: rgba(255, 255, 255, 0.9);
+    }
+    details[open] {
+      background: rgba(255, 255, 255, 0.95);
+    }
   }
 
   summary {
@@ -228,9 +266,18 @@ import BaseLayout from '../../../layouts/BaseLayout.astro';
   .contact-section {
     margin-bottom: 48px;
     padding: 32px;
-    background: #fff;
-    border: 1.5px solid #e0ebe6;
+    background: rgba(255, 255, 255, 0.5);
+    backdrop-filter: blur(20px) saturate(150%);
+    -webkit-backdrop-filter: blur(20px) saturate(150%);
+    border: 1px solid rgba(255, 255, 255, 0.6);
     border-radius: 12px;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.06), inset 0 1px 0 rgba(255, 255, 255, 0.5);
+  }
+
+  @supports not (backdrop-filter: blur(20px)) {
+    .contact-section {
+      background: rgba(255, 255, 255, 0.85);
+    }
   }
 
   .contact-section h2 {
@@ -280,17 +327,31 @@ import BaseLayout from '../../../layouts/BaseLayout.astro';
     color: var(--frog-green);
     font-weight: 500;
     padding: 8px 16px;
-    background: var(--sky-blue-light);
-    border-radius: 8px;
+    background: rgba(255, 255, 255, 0.5);
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    border: 1px solid rgba(255, 255, 255, 0.4);
+    border-radius: 16px;
     transition: all 0.2s ease;
     border-bottom: none;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05), inset 0 1px 0 rgba(255, 255, 255, 0.4);
   }
 
   .email-link:hover {
-    background: var(--sky-blue);
+    background: rgba(255, 255, 255, 0.65);
     color: var(--dark-green);
     transform: translateY(-1px);
     border-bottom: none;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08), inset 0 1px 0 rgba(255, 255, 255, 0.5);
+  }
+
+  @supports not (backdrop-filter: blur(12px)) {
+    .email-link {
+      background: rgba(255, 255, 255, 0.8);
+    }
+    .email-link:hover {
+      background: rgba(255, 255, 255, 0.9);
+    }
   }
 
   /* Page Footer */
@@ -306,6 +367,29 @@ import BaseLayout from '../../../layouts/BaseLayout.astro';
     align-items: center;
     gap: 12px;
     flex-wrap: wrap;
+  }
+
+  .footer-links a {
+    padding: 6px 14px;
+    background: rgba(255, 255, 255, 0.4);
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    border: 1px solid rgba(255, 255, 255, 0.4);
+    border-radius: 16px;
+    transition: all 0.2s;
+    display: inline-block;
+  }
+
+  .footer-links a:hover {
+    background: rgba(255, 255, 255, 0.55);
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+    transform: translateY(-1px);
+  }
+
+  @supports not (backdrop-filter: blur(12px)) {
+    .footer-links a {
+      background: rgba(255, 255, 255, 0.75);
+    }
   }
 
   .separator {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -7,6 +7,14 @@
   --planet-orange: #E07D3A;
   --ring-gold: #D4963A;
   --dark-green: #2D5016;
+
+  /* Liquid Glass Design Variables */
+  --glass-bg: rgba(255, 255, 255, 0.45);
+  --glass-bg-heavy: rgba(255, 255, 255, 0.65);
+  --glass-blur: 20px;
+  --glass-border: rgba(255, 255, 255, 0.5);
+  --glass-shadow: 0 8px 32px rgba(0, 0, 0, 0.08);
+  --glass-inner-glow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
 }
 
 /* Reset & Base */
@@ -20,7 +28,8 @@ body {
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, sans-serif;
   line-height: 1.6;
   color: #333;
-  background: #fafcfa;
+  background: linear-gradient(135deg, #e8f4ec 0%, #dae8f0 30%, #f0ebe4 60%, #e4eff0 100%);
+  background-attachment: fixed;
 }
 
 a {
@@ -56,12 +65,20 @@ img {
 .hero {
   text-align: center;
   padding: 80px 20px;
-  background: linear-gradient(135deg, #d0e8f5, var(--sky-blue), #a8cce0);
+  background: rgba(255, 255, 255, 0.5);
   color: var(--dark-green);
-  border-radius: 12px;
+  border-radius: 16px;
   margin-bottom: 40px;
   position: relative;
   overflow: hidden;
+  border: 1px solid rgba(255, 255, 255, 0.4);
+  box-shadow: var(--glass-shadow), var(--glass-inner-glow);
+}
+
+@supports (backdrop-filter: blur(24px)) {
+  .hero {
+    backdrop-filter: blur(24px) saturate(180%);
+  }
 }
 
 .hero .hero-avatar {
@@ -69,8 +86,10 @@ img {
   height: auto;
   border-radius: 20px;
   margin-bottom: 16px;
-  border: 3px solid #fff;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  border: 3px solid rgba(255, 255, 255, 0.6);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.1),
+              inset 0 0 0 1px rgba(255, 255, 255, 0.4),
+              0 0 24px rgba(176, 212, 232, 0.2);
 }
 
 .hero h1 {
@@ -114,8 +133,21 @@ img {
 }
 
 .hero .btn-primary {
-  background: linear-gradient(135deg, var(--dark-green), #1a3d0e);
+  background: rgba(45, 80, 22, 0.75);
   color: #fff;
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1), inset 0 1px 0 rgba(255, 255, 255, 0.2);
+}
+
+@supports (backdrop-filter: blur(12px)) {
+  .hero .btn-primary {
+    backdrop-filter: blur(12px);
+  }
+}
+
+.hero .btn-primary:hover {
+  background: rgba(45, 80, 22, 0.85);
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.15), inset 0 1px 0 rgba(255, 255, 255, 0.25);
 }
 
 .btn-secondary {


### PR DESCRIPTION
## Summary
- Apply Apple's Liquid Glass design language across all site pages
- Add glass CSS variables and fixed gradient background to global.css
- Convert all surfaces to translucent glass with `backdrop-filter: blur()` and inner glow
- Include `@supports` fallbacks for browsers without backdrop-filter support

## Changes
- **global.css**: Glass variables, gradient body background
- **Hero**: Glass surface, avatar glass ring, glass CTA button
- **Header**: Enhanced blur(24px) saturate(180%), glass pill nav
- **Footer**: Glass surface with inner glow
- **ProjectCard**: Glass cards with hover scale(1.01), glass tags/buttons
- **Post cards**: Glass mini cards
- **Runner's Heart** (landing, support, privacy): Full glass treatment
- **About**: Glass card, avatar glow

## Test plan
- [ ] Verify glass effects render on Chrome/Safari/Firefox
- [ ] Verify fallback styles on browsers without backdrop-filter
- [ ] Verify text readability on all glass surfaces
- [ ] Verify responsive layout preserved at 600px breakpoint
- [ ] Verify hover/transition animations are smooth

Closes #4